### PR TITLE
Update Draw utils Library

### DIFF
--- a/utils/ChristmasTree.ipynb
+++ b/utils/ChristmasTree.ipynb
@@ -1,216 +1,228 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:f72b8b227692da7e7c24fa6ba782c0195246b7fe2c73a172e3d6fd82efbd84a3"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import socket\n",
+    "import networkx as nx\n",
+    "import sys,time\n",
+    "import numpy as np\n",
+    "import random\n",
+    "import matplotlib.cm as cmx\n",
+    "import math\n",
+    "\n",
+    "from sdt_draw_utils import draw_sdt_nx,draw_sdt_nx_nodes,draw_sdt_nx_edges,draw_sdt_nx_node_labels,draw_sdt_nx_edge_labels,sdt_nx_circular,sdt_nx_random,sdt_nx_spectral,sdt_nx_spring,sdt_nx_shell,set_status,pan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n",
+    "except socket.error as msg:\n",
+    "    print(\"[ERROR] %s\\n\" % msg)\n",
+    "    sys.exit(1)\n",
+    "# \n",
+    "try:\n",
+    "    sock.connect((\"127.0.0.1\", 50000))\n",
+    "except socket.error as msg:\n",
+    "    sys.stderr.write(\"[ERROR] %s\\n\" % msg)\n",
+    "    sys.exit(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get some networkx graph\n",
+    "#clear things    \n",
+    "sock.sendall('clear all '.encode())\n",
+    "#    sock.sendall('clear nodes ')    \n",
+    "sock.sendall('layer Worldwind,off '.encode())\n",
+    "sock.sendall('layer Sdt::Kml,off '.encode())\n",
+    "sock.sendall('layer \"All Layers::Sdt::Node Labels,off\" '.encode())\n",
+    "sock.sendall('backgroundColor black '.encode())\n",
+    "sock.sendall('origin 0.0,0.0,0.0 '.encode())\n",
+    "sock.sendall('center 0.0,0,0.0,0.0,c '.encode())\n",
+    "#    sock.sendall('flyto 0.005,0.005,3000.0 ')\n",
+    "sock.sendall('flyto 0.005,0.005,3000.0 '.encode())\n",
+    "#sock.sendall(sdt_com)\n",
+    "#    sock.sendall(\"follow all,on \") \n",
+    "#    draw_sdt_nx(sock,G,node_size=20,alpha=0.7,edge_color=\"blue\",width=0.3)\n",
+    "#Try a colormap\n",
+    "sock.sendall('title \"A Protean Christmas\" '.encode())\n",
+    "sock.sendall('showSdtStatusPanel,off '.encode())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colormap = cmx.get_cmap(\"rainbow\")\n",
+    "numnodes=500\n",
+    "colors = []\n",
+    "for i in range(numnodes):\n",
+    "    colors.append(random.uniform(0.0,1.0))\n",
+    "#Setup tree or cone surface\n",
+    "height = 0.8\n",
+    "radius = 0.4\n",
+    "tangent = radius/height\n",
+    "sl_height = math.sqrt(height*height+radius*radius)\n",
+    "pos = []\n",
+    "\n",
+    "for i in range(numnodes):\n",
+    "#generate a random 3d position on a cone\n",
+    "# Steps: generate random height then random cirle position given height.\n",
+    "#\n",
+    "#        rh=random.betavariate(2,4)\n",
+    "#        rh=np.random.lognormal(mean=0.3,sigma=0.2)\n",
+    "    placed_on_tree = False\n",
+    "    while not placed_on_tree:\n",
+    "        rh= np.random.uniform(0,1)\n",
+    "        rh= rh * height\n",
+    "        top=height-rh\n",
+    "        rradius = top*tangent\n",
+    "    # Need more prob on placing in relationship to radius\n",
+    "        prob = rradius/radius\n",
+    "        if np.random.uniform(0,1) < prob:\n",
+    "            placed_on_tree = True\n",
+    "    radians = random.uniform(0.0,math.pi*2.0*1.0)\n",
+    "    x = (math.sin(radians)*rradius)\n",
+    "    y = (math.cos(radians)*rradius)\n",
+    "    pos.append((x,y,rh))\n",
+    "nodes = [x for x in range(numnodes)]\n",
+    "G = nx.Graph()\n",
+    "G.add_nodes_from(nodes)\n",
+    "draw_sdt_nx_nodes(sock,G,pos,geoPos=False,\n",
+    "            node_color=colors,\n",
+    "            node_shape=\"sphere\",\n",
+    "            node_size=20,\n",
+    "            n_alpha=0.7,\n",
+    "            cmap=colormap)\n",
+    "H=nx.Graph()\n",
+    "H.add_node(0) #Node was previously named star\n",
+    "starpos=[(0.0,0.0,height+0.05)]\n",
+    "draw_sdt_nx_nodes(sock,H,starpos,geoPos=False,\n",
+    "            node_color=\"yellow\",\n",
+    "            node_shape=\"Sphere\",\n",
+    "            node_size=60,\n",
+    "            n_alpha=0.9)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sock.sendall('flyto 0.000,0.00,4000.0 '.encode())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sock.sendall('clear links '.encode())\n",
+    "G.remove_edges_from(G.edges())\n",
+    "# make some edges\n",
+    "limit = 0.07\n",
+    "for n,n_pos in enumerate(pos):\n",
+    "    for k, k_pos in enumerate(pos):\n",
+    "        dist = np.sqrt((k_pos[0]-n_pos[0])**2.0 \n",
+    "                           + (k_pos[1]-n_pos[1])**2.0 \n",
+    "                           + (k_pos[2]-n_pos[2])**2.0)\n",
+    "        if n != k and dist < limit:\n",
+    "            G.add_edge(n,k)\n",
+    "draw_sdt_nx_edges(sock,G,pos,geoPos=False,\n",
+    "            edge_color=\"white\",\n",
+    "            line_widths=1.0,\n",
+    "            l_alpha=0.5,\n",
+    "            style='solid')\n",
+    "sock.sendall('collapseLinks on '.encode())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
     {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import socket\n",
-      "import networkx as nx\n",
-      "import sys,time\n",
-      "import numpy as np\n",
-      "import random\n",
-      "import matplotlib.cm as cmx\n",
-      "import math\n",
-      "\n",
-      "from sdt_draw_utils import draw_sdt_nx,draw_sdt_nx_nodes,draw_sdt_nx_edges,draw_sdt_nx_node_labels,draw_sdt_nx_edge_labels,sdt_nx_circular,sdt_nx_random,sdt_nx_spectral,sdt_nx_spring,sdt_nx_shell,set_status,pan"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "try:\n",
-      "    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n",
-      "except socket.error, msg:\n",
-      "    print(\"[ERROR] %s\\n\" % msg[1])\n",
-      "    sys.exit(1)\n",
-      "# \n",
-      "try:\n",
-      "    sock.connect((\"127.0.0.1\", 50000))\n",
-      "except socket.error, msg:\n",
-      "    sys.stderr.write(\"[ERROR] %s\\n\" % msg[1])\n",
-      "    sys.exit(2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Get some networkx graph\n",
-      "#clear things    \n",
-      "sock.sendall('clear all ')\n",
-      "#    sock.sendall('clear nodes ')    \n",
-      "sock.sendall('layer Worldwind,off ')\n",
-      "sock.sendall('layer Sdt::Kml,off ')\n",
-      "sock.sendall('layer \"All Layers::Sdt::Node Labels,off\" ')\n",
-      "sock.sendall('backgroundColor black ')\n",
-      "sock.sendall('origin 0.0,0.0,0.0 ')\n",
-      "sock.sendall('center 0.0,0,0.0,0.0,c ')\n",
-      "#    sock.sendall('flyto 0.005,0.005,3000.0 ')\n",
-      "sock.sendall('flyto 0.005,0.005,3000.0 ')\n",
-      "#sock.sendall(sdt_com)\n",
-      "#    sock.sendall(\"follow all,on \") \n",
-      "#    draw_sdt_nx(sock,G,node_size=20,alpha=0.7,edge_color=\"blue\",width=0.3)\n",
-      "#Try a colormap\n",
-      "sock.sendall('title \"A Protean Christmas\" ')\n",
-      "sock.sendall('showSdtStatusPanel,off ')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "colormap = cmx.spectral\n",
-      "numnodes=500\n",
-      "colors = []\n",
-      "for i in range(numnodes):\n",
-      "    colors.append(random.uniform(0.0,1.0))\n",
-      "#Setup tree or cone surface\n",
-      "height = 0.8\n",
-      "radius = 0.4\n",
-      "tangent = radius/height\n",
-      "sl_height = math.sqrt(height*height+radius*radius)\n",
-      "pos = []\n",
-      "\n",
-      "for i in range(numnodes):\n",
-      "#generate a random 3d position on a cone\n",
-      "# Steps: generate random height then random cirle position given height.\n",
-      "#\n",
-      "#        rh=random.betavariate(2,4)\n",
-      "#        rh=np.random.lognormal(mean=0.3,sigma=0.2)\n",
-      "    placed_on_tree = False\n",
-      "    while not placed_on_tree:\n",
-      "        rh= np.random.uniform(0,1)\n",
-      "        rh= rh * height\n",
-      "        top=height-rh\n",
-      "        rradius = top*tangent\n",
-      "    # Need more prob on placing in relationship to radius\n",
-      "        prob = rradius/radius\n",
-      "        if np.random.uniform(0,1) < prob:\n",
-      "            placed_on_tree = True\n",
-      "    radians = random.uniform(0.0,math.pi*2.0*1.0)\n",
-      "    x = (math.sin(radians)*rradius)\n",
-      "    y = (math.cos(radians)*rradius)\n",
-      "    pos.append((x,y,rh))\n",
-      "nodes = [x for x in range(numnodes)]\n",
-      "G = nx.Graph()\n",
-      "G.add_nodes_from(nodes)\n",
-      "draw_sdt_nx_nodes(sock,G,pos,geoPos=False,\n",
-      "            node_color=colors,\n",
-      "            node_shape=\"sphere\",\n",
-      "            node_size=20,\n",
-      "            n_alpha=0.7,\n",
-      "            cmap=colormap)\n",
-      "H=nx.Graph()\n",
-      "H.add_node(\"star\")\n",
-      "starpos=[(0.0,0.0,height+0.05)]\n",
-      "draw_sdt_nx_nodes(sock,H,starpos,geoPos=False,\n",
-      "            node_color=\"yellow\",\n",
-      "            node_shape=\"Sphere\",\n",
-      "            node_size=60,\n",
-      "            n_alpha=0.9)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sock.sendall('flyto 0.000,0.00,4000.0 ')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sock.sendall('clear links ')\n",
-      "G.remove_edges_from(G.edges())\n",
-      "# make some edges\n",
-      "limit = 0.07\n",
-      "for n,n_pos in enumerate(pos):\n",
-      "    for k, k_pos in enumerate(pos):\n",
-      "        dist = np.sqrt((k_pos[0]-n_pos[0])**2.0 \n",
-      "                           + (k_pos[1]-n_pos[1])**2.0 \n",
-      "                           + (k_pos[2]-n_pos[2])**2.0)\n",
-      "        if n != k and dist < limit:\n",
-      "            G.add_edge(n,k)\n",
-      "draw_sdt_nx_edges(sock,G,pos,geoPos=False,\n",
-      "            edge_color=\"white\",\n",
-      "            line_widths=1.0,\n",
-      "            l_alpha=0.5,\n",
-      "            style='solid')\n",
-      "sock.sendall('collapseLinks on ')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "on = True\n",
-      "while True:\n",
-      "    if on:\n",
-      "        sock.sendall('layer \"All Layers::Sdt::Network Links,off\" ')\n",
-      "        on=False\n",
-      "    else:\n",
-      "        sock.sendall('layer \"All Layers::Sdt::Network Links,on\" ')\n",
-      "        on=True        \n",
-      "    time.sleep(random.uniform(0.5,3.0))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 11
+     "ename": "BrokenPipeError",
+     "evalue": "[Errno 32] Broken pipe",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mBrokenPipeError\u001b[0m                           Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_11190/2253195676.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mon\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m         \u001b[0msock\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msendall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'layer \"All Layers::Sdt::Network Links,off\" '\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mencode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m         \u001b[0mon\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mBrokenPipeError\u001b[0m: [Errno 32] Broken pipe"
+     ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "on = True\n",
+    "while True:\n",
+    "    if on:\n",
+    "        sock.sendall('layer \"All Layers::Sdt::Network Links,off\" '.encode())\n",
+    "        on=False\n",
+    "    else:\n",
+    "        sock.sendall('layer \"All Layers::Sdt::Network Links,on\" '.encode())\n",
+    "        on=True        \n",
+    "    time.sleep(random.uniform(0.5,3.0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/utils/ChristmasTree.ipynb
+++ b/utils/ChristmasTree.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,21 +155,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "BrokenPipeError",
-     "evalue": "[Errno 32] Broken pipe",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mBrokenPipeError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_11190/2253195676.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mon\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m         \u001b[0msock\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msendall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'layer \"All Layers::Sdt::Network Links,off\" '\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mencode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m         \u001b[0mon\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mBrokenPipeError\u001b[0m: [Errno 32] Broken pipe"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "on = True\n",
     "while True:\n",

--- a/utils/graphml_sdt_utils_example.py
+++ b/utils/graphml_sdt_utils_example.py
@@ -53,7 +53,6 @@ def main(argv):
     toRemove = []
     for n1,n2,d in G.edges(data=True):
         if d['linkSuccessRate']<options.thresh:
-            #G.remove_edge(n1,n2)
             toRemove.append((n1,n2))
     G.remove_edges_from(toRemove)
     G=G.to_undirected(reciprocal=True)
@@ -66,7 +65,6 @@ def main(argv):
     a_scale = 100.0
     altitude = [(a * a_scale) for a in altitude]
 # put the pos data together
-#Issue here. Nodes have string names which cannot be used as indicies
 #Remap node names to integers
     mapping = {}
     i = 0

--- a/utils/graphml_sdt_utils_example.py
+++ b/utils/graphml_sdt_utils_example.py
@@ -31,14 +31,14 @@ def main(argv):
     (options, args) = parser.parse_args()
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    except socket.error, msg:
-        print("[ERROR] %s\n" % msg[1])
+    except socket.error as msg:
+        print("[ERROR] %s\n" % msg)
         sys.exit(1)
 # 
     try:
         sock.connect((options.addr, options.port))
-    except socket.error, msg:
-        sys.stderr.write("[ERROR] %s\n" % msg[1])
+    except socket.error as msg:
+        sys.stderr.write("[ERROR] %s\n" % msg)
         sys.exit(2)
 
 
@@ -48,13 +48,16 @@ def main(argv):
 # Since all edges exist but with potentially very low quality filter the edges
 # H will be a version of graph with edges above a threshold
 #    print G.edges(data=True)    # this should show all possible edges
-    print "number of unfiltered edges :" + str(len(G.edges()))
+    print("number of unfiltered edges :" + str(len(G.edges())))
 # keep minimum of two directed edges
-    for n1,n2,d in G.edges_iter(data=True):
+    toRemove = []
+    for n1,n2,d in G.edges(data=True):
         if d['linkSuccessRate']<options.thresh:
-            G.remove_edge(n1,n2)
+            #G.remove_edge(n1,n2)
+            toRemove.append((n1,n2))
+    G.remove_edges_from(toRemove)
     G=G.to_undirected(reciprocal=True)
-    print "number of filtered edges :" + str(len(G.edges()))
+    print("number of filtered edges :" + str(len(G.edges())))
     H=G
     longitude = nx.get_node_attributes(H,'location_longitude').values()
     latitude = nx.get_node_attributes(H,'location_latitude').values()
@@ -63,7 +66,15 @@ def main(argv):
     a_scale = 100.0
     altitude = [(a * a_scale) for a in altitude]
 # put the pos data together
-    pos = zip(longitude,latitude,altitude)
+#Issue here. Nodes have string names which cannot be used as indicies
+#Remap node names to integers
+    mapping = {}
+    i = 0
+    for node in G.nodes():
+        mapping[node] = i
+        i += 1
+    H = nx.relabel_nodes(G, mapping)
+    pos = list(zip(longitude,latitude,altitude))
 # Because node names from dictionary maybe in different order we need to sort
     bc = []
 #    bc_dict = nx.current_flow_betweenness_centrality(H)
@@ -83,17 +94,17 @@ def main(argv):
         newbs.append(int(np.interp(val,[min(bc),max(bc)],[min_size,max_size])))
 
 # Setup layers and clear things in sdt    
-    sock.sendall('clear all ')
-    sock.sendall('layer "All Layers::Sdt,off" ')
-    sock.sendall('layer "Sdt::Node Symbols" ')
-    sock.sendall('layer "Sdt::Network Links" ')
-    sock.sendall('layer Worldwind,off ')
-    sock.sendall('layer "All Layers::Worldwind::Atmosphere" ')
-    sock.sendall('layer "All Layers::Worldwind::Blue Marble Image" ')
-    sock.sendall('layer "All Layers::Worldwind::MS Virtual Earth Aerial" ')
+    sock.sendall('clear all '.encode()) 
+    sock.sendall('layer "All Layers::Sdt,off" '.encode())
+    sock.sendall('layer "Sdt::Node Symbols" '.encode())
+    sock.sendall('layer "Sdt::Network Links" '.encode())
+    sock.sendall('layer Worldwind,off '.encode())
+    sock.sendall('layer "All Layers::Worldwind::Atmosphere" '.encode())
+    sock.sendall('layer "All Layers::Worldwind::Blue Marble Image" '.encode())
+    sock.sendall('layer "All Layers::Worldwind::MS Virtual Earth Aerial" '.encode())
 #    sock.sendall("follow all ")
 #    sock.sendall("flyto 102.51,-4.50,300000 ")
-    sock.sendall("lookAt 102.51,-4.50,300000,10,70 ")
+    sock.sendall("lookAt 102.51,-4.50,300000,10,70 ".encode())
    
     draw_sdt_nx(sock,H,pos,geoPos=True,
             node_color=newbc,
@@ -102,7 +113,7 @@ def main(argv):
             edge_color="white",
             linewidths=1,
             l_alpha=0.1)
-    sock.sendall('title "3D graphml test with centrality" ')  #    sock.close()
+    sock.sendall('title "3D graphml test with centrality" '.encode())  #    sock.close()
     
 
 if __name__ == '__main__':

--- a/utils/sdt_draw_utils.py
+++ b/utils/sdt_draw_utils.py
@@ -43,14 +43,14 @@ def pan(sock,x,y,z,start=0,end=90, wait= 1.0):
         heading = str(i*4)
         sdt_com = 'lookAt ' + str(x) + ',' + str(y) + ',' + str(z)
         sdt_com = sdt_com + ',' + heading + ',' + pitch + ' '
-        sock.sendall(sdt_com)
+        sock.sendall(sdt_com.encode())
         time.sleep(wait)
     for i in range(start,end):
         pitch = str(end-i)
         heading = str((end-i)*4)
         sdt_com = 'lookAt ' + str(x) + ',' + str(y) + ',' + str(z)
         sdt_com = sdt_com + ',' + heading + ',' + pitch + ' '
-        sock.sendall(sdt_com)
+        sock.sendall(sdt_com.encode())
         time.sleep(wait)
 
 from networkx.drawing.layout import shell_layout,\
@@ -195,12 +195,17 @@ Draw only specified nodes (default G.nodes())
     sdt_com=""
     for n,d in H.nodes(data=True):    
 #check for color array
-        if type(node_color) is types.ListType:
+        if type(node_color) is list:
             n_color=strRgb(node_color[i],0.0,1.0,cmap=cmap)
+        elif type(node_color) is not list and type(node_color) is not str:
+            n_color=strRgb(list(node_color)[i],0.0,1.0,cmap=cmap)
         else:
             n_color = node_color 
-        if type(node_size) is types.ListType:
+        if type(node_size) is list:
             n_size=str(node_size[i])
+        elif type(node_size) is not list and type(node_size) is not int:
+            n_size=str(list(node_size)[i])
+            print(n_size)
         else:
             n_size = str(node_size)       
         sdt_com = sdt_com + "node " + str(n)
@@ -223,19 +228,19 @@ Draw only specified nodes (default G.nodes())
         else:
             posz="0.0"
 # finish z test
-        sdt_com = sdt_com + "," + posz
+        sdt_com += "," + posz
         if not geoPos: 
-            sdt_com = sdt_com + ',c'
+            sdt_com += ',c'
         else:
-            sdt_com = sdt_com + ',g'
-        sdt_com = sdt_com + " symbol " + node_shape + "," 
-        sdt_com = sdt_com + n_color + ",3," + n_size + "," + n_size + "," + str(n_alpha)
+            sdt_com += ',g'
+        sdt_com += " symbol " + node_shape + "," 
+        sdt_com += n_color + ",3," + n_size + "," + n_size + "," + str(n_alpha)
         if nodeLayer:
             sdt_com = sdt_com + " nodeLayer " + str(nodeLayer)
-        sdt_com = sdt_com + " "
+        sdt_com += " "
 #    print sdt_com
         i = i + 1
-    sock.sendall(sdt_com)
+    sock.sendall(sdt_com.encode())
 #    print sdt_com
     return
 
@@ -291,13 +296,13 @@ way is tricky.
         return
 
     sdt_com=""    
-    for node,nbrsdict in H.adjacency_iter():
+    for node,nbrsdict in H.adjacency():
         for nbr,eattr in nbrsdict.items():
             sdt_com = sdt_com + "link " + str(node) + "," + str(nbr) + " line " + str(edge_color) + "," + str(linewidths) + "," + str(l_alpha) + " "
             if edgeLayer:
                 sdt_com = sdt_com + "linkLayer " + str(edgeLayer)
             sdt_com = sdt_com + " "
-    sock.sendall(sdt_com)
+    sock.sendall(sdt_com.encode()) 
 #    print sdt_com
     return
 
@@ -366,7 +371,7 @@ status = string to display in status field
 
 """
     sdt_com= 'status "' + status + '" '
-    sock.sendall(sdt_com)
+    sock.sendall(sdt_com.encode())
     return
 
 # Add code toggle layers and optionally pass in explicit edge labels

--- a/utils/test_sdt_util_withmotion.py
+++ b/utils/test_sdt_util_withmotion.py
@@ -13,25 +13,25 @@ def main(argv):
 
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    except socket.error, msg:
-        print("[ERROR] %s\n" % msg[1])
+    except socket.error as msg:
+        print("[ERROR] %s\n" % msg)
         sys.exit(1)
 # 
     try:
         sock.connect(("127.0.0.1", 50000))
-    except socket.error, msg:
-        sys.stderr.write("[ERROR] %s\n" % msg[1])
+    except socket.error as msg:
+        sys.stderr.write("[ERROR] %s\n" % msg)
         sys.exit(2)
 
-    sock.sendall('clear all ')
+    sock.sendall('clear all '.encode()) 
 #    sock.sendall('clear nodes ')    
-    sock.sendall('layer Worldwind,off ')
-    sock.sendall('layer Sdt::Kml,off ')
-    sock.sendall('layer "All Layers::Sdt::Node Labels,off" ')
-    sock.sendall('backgroundColor gray ')
-    sock.sendall('origin 0.0,0.0,0.0 ')
-    sock.sendall('center 0.0,0,0.0,0.0,c ')
-    sock.sendall('flyto 0.005,0.005,3000.0 ')
+    sock.sendall('layer Worldwind,off '.encode())
+    sock.sendall('layer Sdt::Kml,off '.encode())
+    sock.sendall('layer "All Layers::Sdt::Node Labels,off" '.encode())
+    sock.sendall('backgroundColor gray '.encode())
+    sock.sendall('origin 0.0,0.0,0.0 '.encode())
+    sock.sendall('center 0.0,0,0.0,0.0,c '.encode())
+    sock.sendall('flyto 0.005,0.005,3000.0 '.encode())
 #    sock.sendall("follow all,on ")
 #    draw_sdt_nx(sock,G,node_size=20,alpha=0.7,edge_color="blue",width=0.3)
 # Get some networkx graph
@@ -45,7 +45,7 @@ def main(argv):
     newbs = []
     import operator
     import random
-    maxnode = max(dictbc.iteritems(), key=operator.itemgetter(1))[0]
+    maxnode = max(dictbc.items(), key=operator.itemgetter(1))[0]
 #map to normalize values between 0-1 for colors
     for val in bc:
         newbc.append(np.interp(val,[min(bc),max(bc)],[0,1]))
@@ -63,7 +63,7 @@ def main(argv):
 #    sock.close()
     step = 0.03
     while True:
-        location = G.node[maxnode]['pos']
+        location = G.nodes[maxnode]['pos']
         location[0] = location[0] + random.uniform(-step,step)
         if location[0] > 1.0:
              location[0] = 1.0
@@ -79,7 +79,7 @@ def main(argv):
              location[2] = 1.0
         elif  location[2] < 0.0:
              location[2] = 0.0
-        G.node[maxnode]['pos'] = location
+        G.nodes[maxnode]['pos'] = location
         pos=nx.get_node_attributes(G,'pos')
         G = nx.random_geometric_graph(400,0.2,pos=pos,dim=3)
         dictbc = nx.betweenness_centrality(G)
@@ -95,7 +95,7 @@ def main(argv):
         nbrs = G.neighbors(maxnode)
         for nbr in nbrs:   
             sdt_com = 'unlink ' + str(maxnode) + "," + str(nbr) + " "
-            sock.sendall(sdt_com)       
+            sock.sendall(sdt_com.encode())       
         draw_sdt_nx(sock,G,pos,
                 node_color=newbc,
                 node_size=newbs,

--- a/utils/test_sdt_utils.py
+++ b/utils/test_sdt_utils.py
@@ -29,14 +29,14 @@ def main(argv):
     (options, args) = parser.parse_args()
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    except socket.error, msg:
-        print("[ERROR] %s\n" % msg[1])
+    except socket.error as msg:
+        print("[ERROR] %s\n" % msg)
         sys.exit(1)
 # 
     try:
         sock.connect((options.addr, options.port))
-    except socket.error, msg:
-        sys.stderr.write("[ERROR] %s\n" % msg[1])
+    except socket.error as msg:
+        sys.stderr.write("[ERROR] %s\n" % msg)
         sys.exit(2)
     per = 5
 # Get some networkx graph
@@ -51,16 +51,16 @@ def main(argv):
     for val in bc:
         newbs.append(int(np.interp(val,[min(bc),max(bc)],[10,100])))
 #clear things    
-    sock.sendall('clear all ')
+    sock.sendall('clear all '.encode()) 
 #    sock.sendall('clear nodes ')    
-    sock.sendall('layer Worldwind,off ')
-    sock.sendall('layer Sdt::Kml,off ')
-    sock.sendall('layer "All Layers::Sdt::Node Labels,off" ')
-    sock.sendall('backgroundColor gray ')
-    sock.sendall('origin 0.0,0.0,0.0 ')
-    sock.sendall('center 0.0,0,0.0,0.0,c ')
+    sock.sendall('layer Worldwind,off '.encode())
+    sock.sendall('layer Sdt::Kml,off '.encode())
+    sock.sendall('layer "All Layers::Sdt::Node Labels,off" '.encode())
+    sock.sendall('backgroundColor gray '.encode())
+    sock.sendall('origin 0.0,0.0,0.0 '.encode())
+    sock.sendall('center 0.0,0,0.0,0.0,c '.encode())
 #    sock.sendall('flyto 0.005,0.005,3000.0 ')
-    sock.sendall('lookAt 0.005,0.005,3000.0 ')
+    sock.sendall('lookAt 0.005,0.005,3000.0 '.encode())
 #    sock.sendall("follow all,on ") 
 #    draw_sdt_nx(sock,G,node_size=20,alpha=0.7,edge_color="blue",width=0.3)
 #Try a colormap
@@ -72,12 +72,12 @@ def main(argv):
             linewidths=1,
             cmap=colormap)
     set_status(sock,"Erdos Circular Layout")
-    sock.sendall('title "Erdos-renyi Graph with Circular Layout" ')
+    sock.sendall('title "Erdos-renyi Graph with Circular Layout" '.encode())
 #DONE
     time.sleep(per)
 
 #clear things    
-    sock.sendall('clear all ')
+    sock.sendall('clear all '.encode())
     draw_sdt_nx(sock,G,
                 node_color=newbc,
                 node_size=newbs,
@@ -85,12 +85,12 @@ def main(argv):
                 edge_color="blue",
                 linewidths=1,
                 cmap=colormap)
-    set_status(sock,"Erdos Spring layout")
-    sock.sendall('title "Erdos-renyi Graph Spring Layout" ')
+    set_status(sock,"Erdos Spring layout") 
+    sock.sendall('title "Erdos-renyi Graph Spring Layout" '.encode())
     time.sleep(per)
 
 #clear things do a chemical network   
-    sock.sendall('clear all ')
+    sock.sendall('clear all '.encode())
     G=nx.Graph()
     G.add_nodes_from([1,2,3,4,5,6],size=100,color=0.9)
     G.add_nodes_from([7,8],size=300,color=0.5)
@@ -106,10 +106,10 @@ def main(argv):
                 linewidths=1,
                 cmap=colormap)
     set_status(sock,"Alcohol Molecule")
-    sock.sendall('title "Molecule - Alcohol" ')
+    sock.sendall('title "Molecule - Alcohol" '.encode())
     time.sleep(per)
-    sock.sendall('clear all ')
-    sock.sendall('backgroundColor black ')
+    sock.sendall('clear all '.encode())
+    sock.sendall('backgroundColor black '.encode())
     G = nx.barabasi_albert_graph(300,6)
     pos=nx.spring_layout(G,dim=3,iterations=100)
     bc = nx.betweenness_centrality(G).values()
@@ -130,9 +130,9 @@ def main(argv):
                 l_alpha=0.1,
                 cmap=colormap)
     set_status(sock,"Barabasi Graph")
-    sock.sendall('title "Barabasi Graph" ')
+    sock.sendall('title "Barabasi Graph" '.encode())
     time.sleep(per)
-    sock.sendall('clear all ')
+    sock.sendall('clear all '.encode())
 # Now do a random geometric graph in 3D
 # Get some networkx graph
     G = nx.random_geometric_graph(400,0.2,dim=3)
@@ -155,10 +155,10 @@ def main(argv):
                 l_alpha=0.3,
                 cmap=colormap)
 #    sock.sendall(sock,'title "Colormap Tests" ')
-    sock.sendall('follow all ')
+    sock.sendall('follow all '.encode())
     pan (sock, 0.005,0.005,3000.0, 0, 90,wait=0.1)
-    sock.sendall('clear all ')
-    sock.sendall('title "Colormap Tests" ')
+    sock.sendall('clear all '.encode())
+    sock.sendall('title "Colormap Tests" '.encode())
     colormaps=[cmx.hot,
                 cmx.afmhot,
                 cmx.autumn,


### PR DESCRIPTION
The Python Draw Utils Library hasn't been updated and only works with python 2.x and NetworkX 1.x. The bulk of the migration is fixing print calls and try / except blocks to match python 3 syntax. I verified all scripts are working with a conda environment of Python 3.11.13 and NetworkX 3.5 using SDT3D v2.3 Worldwind v2.1d on a Ubuntu 22.04.02 VM.